### PR TITLE
refactor div inside switch

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import '../assets/App.css';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
-import Header from '././components/Header';
+import Header from './components/Header';
 
-import routes from './router/routes';
+import Main from './components/Main'
 
 class App extends Component {
   render() {
@@ -12,15 +12,7 @@ class App extends Component {
       <Router>
         <div className="App">
           <Header title="Home"/>
-          <Switch>
-            <div className="wrapper">
-              {
-                routes.map(({path, component, exact}, i) => {
-                  return <Route key={i} exact={exact} path={path} component={component} />
-                })
-              }
-            </div>
-          </Switch>
+          <Main />
         </div>
       </Router> 
     );

--- a/src/app/components/Main.js
+++ b/src/app/components/Main.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import routes from '../router/routes';
+
+const Main = () => (
+  <div className="wrapper">
+    <Switch>
+      {
+        routes.map(({path, component, exact}, i) => {
+          return <Route key={i} exact={exact} path={path} component={component} />
+        })
+      }
+    </Switch>
+  </div>
+)
+
+export default Main;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { store } from './app/store/store';
 
 ReactDOM.render(
   <Provider store={store}>
-      <App /> 
+    <App /> 
   </Provider>,
 	document.getElementById('root')
 );


### PR DESCRIPTION
I didn't notice earlier the console was throwing an error because it was looking for a `<Route />` inside switch, but instead it found a DOM element, `<div className="wrapper" />`.

I moved the routes and wrapper to a separate component file `Main.js`, and imported it into `App.js`.

The console should no longer throw an error.
