### PR TITLE
Add company cards on Companies page

### DIFF
--- a/src/app/components/Companies.js
+++ b/src/app/components/Companies.js
@@ -1,25 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import getCompaniesData from '../store/actions/getCompaniesData';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
-import Chip from '@material-ui/core/Chip';
-import Link from '@material-ui/core/Link';
-
-// Styles
-const centerText = { textAlign: 'center' };
-const tagStyle = { height: '25px', marginRight: '5px', backgroundColor: '#65B8DE' };
-
-// Helper function
-const chooseRandomTags = (tagsArray, n) => {
-  // Shuffle array
-  const shuffled = tagsArray.sort(() => 0.5 - Math.random());
-
-  // Get sub-array of first n elements after shuffled
-  const selected = shuffled.slice(0, n);
-
-  return selected;
-};
+import getCompaniesData from '../store/actions/getCompaniesData';
+import CompanyCard from './CompanyCard';
 
 class Companies extends React.Component {
   componentDidMount() {
@@ -29,37 +13,16 @@ class Companies extends React.Component {
 
   renderCompaniesList() {
     const { companies } = this.props;
-    return companies.map((company, index) => {
-      return (
-        <div key={index} style={{ height: '100px' }}>
-          <h4 style={{ ...centerText, margin: '0 0 20px' }}>
-            <Link href={'/companies/' + company.id} color="inherit">
-              {company.name}
-            </Link>
-          </h4>
-          <div style={{ ...centerText }}>
-            {/*Displays 3 tech tags*/}
-            {chooseRandomTags(company.tech, 3).map(tag => (
-              <Chip label={tag.label} key={tag.value} style={tagStyle} />
-            ))}
-            {/*Displays 2 industry tags*/}
-            {chooseRandomTags(company.industry, 2).map(tag => (
-              <Chip label={tag.label} key={tag.value} style={tagStyle} />
-            ))}
-          </div>
-          <Divider style={{ margin: '20px' }} />
-        </div>
-      );
+    return companies.map(company => {
+      return <CompanyCard key={company.id} {...company} />;
     });
   }
 
   render() {
-    console.log(this.props);
     return (
       <Grid container justify="center">
         <Grid item xs={12}>
-          <h1 style={{ ...centerText, fontSize: '1rem' }}>Bridge Company Certification</h1>
-          {/*This is where the toggle buttons will go*/}
+          <h1 style={{ textAlign: 'center', fontSize: '1rem' }}>Bridge Company Certification</h1>
           <Divider variant="middle" style={{ margin: '1rem 2rem 2rem' }} />
           {this.renderCompaniesList()}
         </Grid>

--- a/src/app/components/Companies.js
+++ b/src/app/components/Companies.js
@@ -32,7 +32,7 @@ class Companies extends React.Component {
       return (
         <div key={index} style={{ height: '100px' }}>
           <h4 style={{ ...centerText, margin: '0 0 20px' }}>
-            <a href="#">{company.name}</a>
+            <a href={'/companies/' + company.id}>{company.name}</a>
           </h4>
           <div style={{ ...centerText }}>
             {/*Displays 3 tech tags*/}

--- a/src/app/components/Companies.js
+++ b/src/app/components/Companies.js
@@ -1,31 +1,66 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import getCompaniesData from '../store/actions/getCompaniesData';
+import Grid from '@material-ui/core/Grid';
+import Divider from '@material-ui/core/Divider';
+import Chip from '@material-ui/core/Chip';
+
+// Styles
+const centerText = { textAlign: 'center' };
+const tagStyle = { height: '25px', marginRight: '5px', backgroundColor: '#65B8DE' };
+
+// Helper function
+const chooseRandomTags = (tagsArray, n) => {
+  // Shuffle array
+  const shuffled = tagsArray.sort(() => 0.5 - Math.random());
+
+  // Get sub-array of first n elements after shuffled
+  const selected = shuffled.slice(0, n);
+
+  return selected;
+};
 
 class Companies extends React.Component {
   componentDidMount() {
-    const { getCompaniesData } = this.props; // eslint-disable-line
+    const { getCompaniesData } = this.props;
     getCompaniesData();
   }
 
   renderCompaniesList() {
-    const { companies } = this.props; // eslint-disable-line
+    const { companies } = this.props;
     return companies.map((company, index) => {
       return (
-        // placeholder for company cards
-        <div key={index}>
-          <h4>{company.name}</h4>
+        <div key={index} style={{ height: '100px' }}>
+          <h4 style={{ ...centerText, margin: '0 0 20px' }}>
+            <a href="#">{company.name}</a>
+          </h4>
+          <div style={{ ...centerText }}>
+            {/*Displays 3 tech tags*/}
+            {chooseRandomTags(company.tech, 3).map(tag => (
+              <Chip label={tag.label} key={tag.value} style={tagStyle} />
+            ))}
+            {/*Displays 2 industry tags*/}
+            {chooseRandomTags(company.industry, 2).map(tag => (
+              <Chip label={tag.label} key={tag.value} style={tagStyle} />
+            ))}
+          </div>
+          <Divider style={{ margin: '20px' }} />
         </div>
       );
     });
   }
 
   render() {
+    console.log(this.props);
     return (
-      <div style={{ padding: 50 }}>
-        <h1>Companies</h1>
-        {this.renderCompaniesList()}
-      </div>
+      <Grid container justify="center">
+        <Grid item xs={12}>
+          <h1 style={{ ...centerText, fontSize: '1rem' }}>Bridge Company Certification</h1>
+          {/*This is where the toggle buttons will go*/}
+          <Divider variant="middle" style={{ margin: '1rem 2rem 2rem' }} />
+          {this.renderCompaniesList()}
+        </Grid>
+      </Grid>
     );
   }
 }

--- a/src/app/components/Companies.js
+++ b/src/app/components/Companies.js
@@ -4,6 +4,7 @@ import getCompaniesData from '../store/actions/getCompaniesData';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
 import Chip from '@material-ui/core/Chip';
+import Link from '@material-ui/core/Link';
 
 // Styles
 const centerText = { textAlign: 'center' };
@@ -32,7 +33,9 @@ class Companies extends React.Component {
       return (
         <div key={index} style={{ height: '100px' }}>
           <h4 style={{ ...centerText, margin: '0 0 20px' }}>
-            <a href={'/companies/' + company.id}>{company.name}</a>
+            <Link href={'/companies/' + company.id} color="inherit">
+              {company.name}
+            </Link>
           </h4>
           <div style={{ ...centerText }}>
             {/*Displays 3 tech tags*/}

--- a/src/app/components/CompanyCard.js
+++ b/src/app/components/CompanyCard.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import Divider from '@material-ui/core/Divider';
+import Chip from '@material-ui/core/Chip';
+import { Link } from 'react-router-dom';
+
+// Styles
+const tagStyle = { height: '25px', marginRight: '5px', backgroundColor: '#65B8DE' };
+
+// Helper function
+const chooseRandomTags = (tagsArray, n) => {
+  // Shuffle array
+  const shuffled = tagsArray.sort(() => 0.5 - Math.random());
+
+  // Get sub-array of first n elements after shuffled
+  const selected = shuffled.slice(0, n);
+
+  return selected;
+};
+
+const CompanyCard = ({ id, name, industry, tech }) => {
+  return (
+    <div>
+      <h4 style={{ textAlign: 'center', margin: '0 0 20px' }}>
+        <Link to={`/companies/${id}`}>{name}</Link>
+      </h4>
+      <div style={{ textAlign: 'center' }}>
+        {chooseRandomTags(tech, 3).map(tag => (
+          <Chip label={tag.label} key={tag.value} style={tagStyle} />
+        ))}
+
+        {chooseRandomTags(industry, 2).map(tag => (
+          <Chip label={tag.label} key={tag.value} style={tagStyle} />
+        ))}
+      </div>
+      <Divider style={{ margin: '20px' }} />
+    </div>
+  );
+};
+
+export default CompanyCard;


### PR DESCRIPTION
And I said I wasn't going to work tonight ha.

The styling could be improved but that's all I could muster up for now. I know @susiekims will need this page to add the toggle button and I didn't want it to be a blocker.

Note: The company names DO NOT currently link to their respective pages. I will update that once the PR for the change I made in the backend is approved. The id can be accessed via `company.id`.

A max of 5 random tags display for each company- 3 tech and 2 industry. Let me know what you think! 

Thanks! 

![image](https://user-images.githubusercontent.com/26798587/54063089-3c2f8780-41d8-11e9-94f2-0beca5b8d620.png)


 