### PR TITLE
restoring scroll position when changing routes

### DIFF
--- a/src/app/components/Homepage.js
+++ b/src/app/components/Homepage.js
@@ -17,7 +17,7 @@ const Homepage = ({ companyId, postSuccess, reset }) => {
     <Grid item xs={10} sm={8} md={6}>
       <h1>Bridge Company Certification</h1>
       <CompanyForm />
-      {postSuccess && <Redirect to={`/companies/${companyId}`} />}
+      {postSuccess && <Redirect push to={`/companies/${companyId}`} />}
     </Grid>
   );
 };

--- a/src/app/components/Main.js
+++ b/src/app/components/Main.js
@@ -2,15 +2,18 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import routes from '../router/routes';
 import Wrapper from './Wrapper';
+import ScrollToTop from './ScrollToTop';
 
 const Main = () => (
-  <Wrapper>
-    <Switch>
-      {routes.map(({ path, component, exact }, i) => {
-        return <Route key={i} exact={exact} path={path} component={component} />;
-      })}
-    </Switch>
-  </Wrapper>
+  <ScrollToTop>
+    <Wrapper>
+      <Switch>
+        {routes.map(({ path, component, exact }, i) => {
+          return <Route key={i} exact={exact} path={path} component={component} />;
+        })}
+      </Switch>
+    </Wrapper>
+  </ScrollToTop>
 );
 
 export default Main;

--- a/src/app/components/ScrollToTop.js
+++ b/src/app/components/ScrollToTop.js
@@ -1,0 +1,16 @@
+import { Component } from 'react';
+import { withRouter } from 'react-router';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/app/components/Student.js
+++ b/src/app/components/Student.js
@@ -15,7 +15,7 @@ const Student = ({ postSuccess, studentId, reset }) => {
   return (
     <Grid item xs={10} sm={8} md={6}>
       <StudentForm />
-      {postSuccess && <Redirect to={`/students`} />}
+      {postSuccess && <Redirect push to={`/students`} />}
     </Grid>
   );
 };


### PR DESCRIPTION
Before if you were scrolled halfway down a page, then clicked on a link to a new page, you would be dropped off at the new page also scrolled halfway. This was particularly noticeable when you submitted the company form, then was redirected to the Company page already scrolled to the bottom. Not good UX!

I implemented the solution suggested by the react-router training docs here: https://reacttraining.com/react-router/web/guides/scroll-restoration