### PR TITLE
Fix select for mobile

### DIFF
--- a/src/app/components/form/Dropdown.js
+++ b/src/app/components/form/Dropdown.js
@@ -161,15 +161,8 @@ const components = {
   ValueContainer
 };
 
-const IntegrationReactSelect = ({
-  classes,
-  theme,
-  suggestions,
-  label,
-  input,
-  meta
-}) => {
-  const {  touched, invalid, error, active } = meta
+const IntegrationReactSelect = ({ classes, theme, suggestions, label, input, meta }) => {
+  const { touched, invalid, error, active } = meta;
   const selectStyles = {
     input: base => ({
       ...base,
@@ -195,9 +188,7 @@ const IntegrationReactSelect = ({
           {...input}
           options={suggestions}
           components={components}
-          onBlur={() => {
-            input.onBlur([...input.value]);
-          }}
+          onBlur={e => e.preventDefault()}
           placeholder={''}
           isMulti
           meta={meta}


### PR DESCRIPTION
https://github.com/JedWatson/react-select/issues/2692

`I finally found that the issue was due to this property blurInputOnSelect which is true by default in mobile devices. So, when the user selects an option the library triggers a blur event. So far the only solution I found working is to replace onBlur={input.onBlur(input.value)} with onBlur={event => event.preventDefault()}`

I implement the suggested solution and seems to work, both mobile and desktop. Tested in BrowserStack (iPhone X chrome).